### PR TITLE
Rename previous "recommended" config to "dprint"

### DIFF
--- a/.changeset/spotty-pianos-check.md
+++ b/.changeset/spotty-pianos-check.md
@@ -1,0 +1,5 @@
+---
+"@effect/eslint-plugin": minor
+---
+
+Rename previous "recommended" config to "dprint"

--- a/src/configs/dprint.ts
+++ b/src/configs/dprint.ts
@@ -1,7 +1,7 @@
 import disableConflictRules from "@effect/eslint-plugin/configs/disable-conflict-rules"
 import * as plugin from "@effect/eslint-plugin/plugin"
 
-const recommended = [
+export default plugin.configs.dprint = [
   ...disableConflictRules,
   {
     plugins: {
@@ -12,6 +12,3 @@ const recommended = [
     },
   },
 ]
-
-plugin.configs.recommended = recommended
-export default recommended

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import * as plugin from "@effect/eslint-plugin/plugin"
-import "@effect/eslint-plugin/configs/recommended"
+import "@effect/eslint-plugin/configs/dprint"
 
 export * from "@effect/eslint-plugin/plugin"
 export default plugin

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -12,5 +12,5 @@ export const rules = {
 // so in this file we only stub out known configs
 // but they actually get injected in their respective file
 export const configs = {
-  recommended: [] as Array<any>,
+  dprint: [] as Array<any>,
 }


### PR DESCRIPTION
## Type

<!--
What type of change is this? Please check all applicable.
-->

- [X] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR renames old recommended config to dprint. This will allow using the effect recommended config to provide rules that does not require typechecking.
